### PR TITLE
Better UX V2

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"log/slog"
 	"sync/atomic"
 
 	"github.com/brody192/locomotive/internal/logger"
@@ -17,8 +18,14 @@ func handleDeployLogsAsync(ctx context.Context, deployLogsProcessed *atomic.Int6
 			case <-ctx.Done():
 				return
 			case logs := <-serviceLogTrack:
-				if err := webhook.SendDeployLogsWebhook(logs); err != nil {
-					logger.Stderr.Error("error sending deploy logs webhook(s)", logger.ErrAttr(err))
+				if serializedLogs, err := webhook.SendDeployLogsWebhook(logs); err != nil {
+					attrs := []any{logger.ErrAttr(err)}
+
+					if serializedLogs != nil {
+						attrs = append(attrs, slog.String("serialized_logs", string(serializedLogs)))
+					}
+
+					logger.Stderr.Error("error sending deploy logs webhook(s)", attrs...)
 
 					continue
 				}
@@ -36,8 +43,14 @@ func handleHttpLogsAsync(ctx context.Context, httpLogsProcessed *atomic.Int64, h
 			case <-ctx.Done():
 				return
 			case logs := <-httpLogTrack:
-				if err := webhook.SendHttpLogsWebhook(logs); err != nil {
-					logger.Stderr.Error("error sending http logs webhook(s)", logger.ErrAttr(err))
+				if serializedLogs, err := webhook.SendHttpLogsWebhook(logs); err != nil {
+					attrs := []any{logger.ErrAttr(err)}
+
+					if serializedLogs != nil {
+						attrs = append(attrs, slog.String("serialized_logs", string(serializedLogs)))
+					}
+
+					logger.Stderr.Error("error sending http logs webhook(s)", attrs...)
 
 					continue
 				}

--- a/internal/config/data.go
+++ b/internal/config/data.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"regexp"
+
 	"github.com/brody192/locomotive/internal/logline/reconstructor/reconstruct_axiom"
 	"github.com/brody192/locomotive/internal/logline/reconstructor/reconstruct_betterstack"
 	"github.com/brody192/locomotive/internal/logline/reconstructor/reconstruct_datadog"
@@ -9,6 +11,8 @@ import (
 	"github.com/brody192/locomotive/internal/logline/reconstructor/reconstruct_papertrail"
 	"github.com/brody192/locomotive/internal/logline/reconstructor/reconstruct_sentry"
 )
+
+var schemeRegex = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+.-]*://`)
 
 const (
 	WebhookModeJson        WebhookMode = "json"
@@ -37,13 +41,13 @@ var WebhookModeToConfig = map[WebhookMode]WebhookConfig{
 		HTTPLogReconstructorFunc:        reconstruct_json.HttpLogsJsonLines,
 	},
 	WebhookModeLoki: {
-		ExpectedHostContains:            "loki",
+		ExpectedHostContains:            []string{"loki", "grafana"},
 		Headers:                         map[string]string{},
 		EnvironmentLogReconstructorFunc: reconstruct_loki.EnvironmentLogStreams,
 		HTTPLogReconstructorFunc:        reconstruct_loki.HttpLogStreams,
 	},
 	WebhookModePapertrail: {
-		ExpectedHostContains: "solarwinds",
+		ExpectedHostContains: []string{"solarwinds"},
 		ExpectedHeaders:      []string{"Authorization"},
 		Headers: map[string]string{
 			// Note: Papertrail accepts JSON Lines, yet only accepts the JSON content type.
@@ -53,28 +57,28 @@ var WebhookModeToConfig = map[WebhookMode]WebhookConfig{
 		HTTPLogReconstructorFunc:        reconstruct_papertrail.HttpLogsJsonLines,
 	},
 	WebhookModeDatadog: {
-		ExpectedHostContains:            "datadog",
+		ExpectedHostContains:            []string{"datadog"},
 		ExpectedHeaders:                 []string{"DD-API-KEY", "DD-APPLICATION-KEY"},
 		Headers:                         map[string]string{},
 		EnvironmentLogReconstructorFunc: reconstruct_datadog.EnvironmentLogsJsonArray,
 		HTTPLogReconstructorFunc:        reconstruct_datadog.HttpLogsJsonArray,
 	},
 	WebhookModeAxiom: {
-		ExpectedHostContains:            "axiom",
+		ExpectedHostContains:            []string{"axiom"},
 		ExpectedHeaders:                 []string{"Authorization"},
 		Headers:                         map[string]string{},
 		EnvironmentLogReconstructorFunc: reconstruct_axiom.EnvironmentLogsJsonArray,
 		HTTPLogReconstructorFunc:        reconstruct_axiom.HttpLogsJsonArray,
 	},
 	WebhookModeBetterstack: {
-		ExpectedHostContains:            "betterstack",
+		ExpectedHostContains:            []string{"betterstack"},
 		ExpectedHeaders:                 []string{"Authorization"},
 		Headers:                         map[string]string{},
 		EnvironmentLogReconstructorFunc: reconstruct_betterstack.EnvironmentLogsJsonArray,
 		HTTPLogReconstructorFunc:        reconstruct_betterstack.HttpLogsJsonArray,
 	},
 	WebhookModeSentry: {
-		ExpectedHostContains: "sentry",
+		ExpectedHostContains: []string{"sentry"},
 		ExpectedHeaders:      []string{"X-Sentry-Auth"},
 		Headers: map[string]string{
 			"Content-Type": "application/x-sentry-envelope",

--- a/internal/config/helpers.go
+++ b/internal/config/helpers.go
@@ -1,0 +1,13 @@
+package config
+
+import "strings"
+
+func containsAnyHost(hostname string, expectedHosts []string) bool {
+	for _, expectedHost := range expectedHosts {
+		if strings.Contains(hostname, expectedHost) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -16,7 +16,7 @@ type (
 )
 
 type WebhookConfig struct {
-	ExpectedHostContains string
+	ExpectedHostContains []string
 	ExpectedHeaders      []string
 
 	Headers AdditionalHeaders

--- a/internal/webhook/generic/webhook.go
+++ b/internal/webhook/generic/webhook.go
@@ -20,22 +20,22 @@ var acceptedStatusCodes = []int{
 	http.StatusCreated,
 }
 
-func SendWebhookForDeployLogs(logs []environment_logs.EnvironmentLogWithMetadata, client *http.Client) error {
+func SendWebhookForDeployLogs(logs []environment_logs.EnvironmentLogWithMetadata, client *http.Client) (serializedLogs []byte, err error) {
 	payload, err := config.WebhookModeToConfig[config.Global.WebhookMode].EnvironmentLogReconstructorFunc(logs)
 	if err != nil {
-		return fmt.Errorf("failed to reconstruct deploy log lines: %w", err)
+		return nil, fmt.Errorf("failed to reconstruct deploy log lines: %w", err)
 	}
 
-	return sendRawWebhook(payload, config.Global.WebhookUrl, config.Global.AdditionalHeaders, client)
+	return payload, sendRawWebhook(payload, config.Global.WebhookUrl, config.Global.AdditionalHeaders, client)
 }
 
-func SendWebhookForHttpLogs(logs []http_logs.DeploymentHttpLogWithMetadata, client *http.Client) error {
+func SendWebhookForHttpLogs(logs []http_logs.DeploymentHttpLogWithMetadata, client *http.Client) (serializedLogs []byte, err error) {
 	payload, err := config.WebhookModeToConfig[config.Global.WebhookMode].HTTPLogReconstructorFunc(logs)
 	if err != nil {
-		return fmt.Errorf("failed to reconstruct http log lines: %w", err)
+		return nil, fmt.Errorf("failed to reconstruct http log lines: %w", err)
 	}
 
-	return sendRawWebhook(payload, config.Global.WebhookUrl, config.Global.AdditionalHeaders, client)
+	return payload, sendRawWebhook(payload, config.Global.WebhookUrl, config.Global.AdditionalHeaders, client)
 }
 
 func sendRawWebhook(logs []byte, url url.URL, additionalHeaders config.AdditionalHeaders, client *http.Client) error {

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -8,18 +8,18 @@ import (
 	"github.com/brody192/locomotive/internal/webhook/generic"
 )
 
-func SendDeployLogsWebhook(logs []environment_logs.EnvironmentLogWithMetadata) error {
-	if err := generic.SendWebhookForDeployLogs(logs, client); err != nil {
-		return fmt.Errorf("failed to send webhook for deploy logs: %w", err)
+func SendDeployLogsWebhook(logs []environment_logs.EnvironmentLogWithMetadata) (serializedLogs []byte, err error) {
+	if serializedLogs, err := generic.SendWebhookForDeployLogs(logs, client); err != nil {
+		return serializedLogs, fmt.Errorf("failed to send webhook for deploy logs: %w", err)
 	}
 
-	return nil
+	return nil, nil
 }
 
-func SendHttpLogsWebhook(logs []http_logs.DeploymentHttpLogWithMetadata) error {
-	if err := generic.SendWebhookForHttpLogs(logs, client); err != nil {
-		return fmt.Errorf("failed to send webhook for http logs: %w", err)
+func SendHttpLogsWebhook(logs []http_logs.DeploymentHttpLogWithMetadata) (serializedLogs []byte, err error) {
+	if serializedLogs, err := generic.SendWebhookForHttpLogs(logs, client); err != nil {
+		return serializedLogs, fmt.Errorf("failed to send webhook for http logs: %w", err)
 	}
 
-	return nil
+	return nil, nil
 }


### PR DESCRIPTION
- Automatically adds `https` as a schema if one isn't present in the given webhook URL.
- Stricter URL parsing.
- Logs the serialized log if sending a webhook fails.
- Check for `grafana` as an acceptable host substring for the `loki` mode.