### PR TITLE
Add beta image workflow

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -1,0 +1,55 @@
+name: Beta
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+    branches: [main]
+
+concurrency:
+  group: beta-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    if: contains(github.event.pull_request.labels.*.name, 'beta')
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      push: true
+      image: ghcr.io/${{ github.repository }}
+    permissions:
+      packages: write
+    secrets: inherit
+
+  manifest:
+    name: Push Beta Manifest
+    needs: build
+    if: contains(github.event.pull_request.labels.*.name, 'beta')
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digest-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push manifest
+        working-directory: /tmp/digests
+        run: |
+          BRANCH="${{ github.head_ref }}"
+          BRANCH="${BRANCH##*/}"
+          docker buildx imagetools create \
+            -t ghcr.io/${{ github.repository }}:beta_${BRANCH} \
+            $(printf 'ghcr.io/${{ github.repository }}@sha256:%s ' *)


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow that builds and pushes a beta-tagged Docker image when a PR has the `beta` label
- Rebuilds automatically on each push while the label is present
- Image is tagged as `beta_<branch>` (e.g. `beta_test-thing` for branch `brody/test-thing`)
- Uses the existing `docker-build.yml` reusable workflow for multi-platform builds

## Test plan
- [ ] Open a PR with the `beta` label and verify the workflow triggers
- [ ] Push a commit to the PR and verify it rebuilds
- [ ] Check GHCR for the `beta_<branch>` tagged image

Made with [Cursor](https://cursor.com)