### PR TITLE
feat: suportar múltiplos environment ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,30 +43,19 @@ Configuration is done through environment variables. See explanation and example
 
     </br>
 
-- `LOCOMOTIVE_ENVIRONMENT_ID` - The ID of the environment your services are in.
+- `LOCOMOTIVE_ENVIRONMENT_IDS` - The IDs of the environments your services are in.
 
-    **Required**.
+    **Optional**.
 
-    - Auto-filled to the current environment ID.
+    - Supports a single environment ID.
+    - Supports multiple environment IDs, separated with a comma.
+    - If omitted or empty, Locomotive queries Railway for all accessible environments and uses those.
 
-    Make sure to deploy Locomotive into the same environment as the services you want to monitor.
+    Make sure to deploy Locomotive into the same environments as the services you want to monitor.
 
     [Railway Best Practices](https://docs.railway.com/overview/best-practices#deploying-related-services-into-the-same-project)
 
-    Upon startup, Locomotive will verify that all the services exist within the set environment. If the environment does not exist, Locomotive will exit with an API error message.
-
-    If that check fails with an unauthorized error, you are likely using the wrong kind of API token.
-
-    </br>
-
-- `LOCOMOTIVE_SERVICE_IDS` - The IDs of the services you want to monitor.
-
-    **Required**.
-
-    - Supports a single service ID.
-    - Supports multiple service IDs, separated with a comma.
-
-    Upon startup, Locomotive will verify that all the services exist within the set environment. If any services do not exist, Locomotive will exit with an error and provide a list of the missing services.
+    Upon startup, Locomotive will fetch logs for all successful deployments in the configured environments. If an environment does not exist, Locomotive will exit with an API error message.
 
     If that check fails with an unauthorized error, you are likely using the wrong kind of API token.
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -27,9 +27,7 @@ type WebhookConfig struct {
 
 type config struct {
 	RailwayApiKey uuid.UUID   `env:"RAILWAY_API_KEY,required,notEmpty"`
-	EnvironmentId uuid.UUID   `env:"ENVIRONMENT_ID,required,notEmpty"`
-	ServiceIds    []uuid.UUID `env:"SERVICE_IDS,required,notEmpty"`
-
+	EnvironmentIds []uuid.UUID `env:"ENVIRONMENT_IDS"`
 	WebhookUrl        url.URL           `env:"WEBHOOK_URL,required,notEmpty"`
 	AdditionalHeaders AdditionalHeaders `env:"ADDITIONAL_HEADERS"`
 	WebhookMode       WebhookMode       `env:"WEBHOOK_MODE" envDefault:"json"`

--- a/internal/railway/environment_ids.go
+++ b/internal/railway/environment_ids.go
@@ -1,0 +1,37 @@
+package railway
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/brody192/locomotive/internal/railway/gql/queries"
+	"github.com/flexstack/uuid"
+)
+
+func FetchAllEnvironmentIDs(ctx context.Context, g *GraphQLClient) ([]uuid.UUID, error) {
+	if g == nil || g.Client == nil {
+		return nil, fmt.Errorf("graphql client is nil")
+	}
+
+	projectData := &queries.ProjectsData{}
+
+	if err := g.Client.Exec(ctx, queries.ProjectsQuery, &projectData, nil); err != nil {
+		return nil, err
+	}
+
+	environmentIDs := make([]uuid.UUID, 0)
+	seen := make(map[uuid.UUID]struct{})
+
+	for _, project := range projectData.Projects.Edges {
+		for _, environment := range project.Node.Environments.Edges {
+			if _, ok := seen[environment.Node.ID]; ok {
+				continue
+			}
+
+			seen[environment.Node.ID] = struct{}{}
+			environmentIDs = append(environmentIDs, environment.Node.ID)
+		}
+	}
+
+	return environmentIDs, nil
+}

--- a/internal/railway/gql/queries/projects.graphql
+++ b/internal/railway/gql/queries/projects.graphql
@@ -1,0 +1,15 @@
+query projects {
+	projects {
+		edges {
+			node {
+				environments {
+					edges {
+						node {
+							id
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/internal/railway/gql/queries/projects_data.go
+++ b/internal/railway/gql/queries/projects_data.go
@@ -1,0 +1,19 @@
+package queries
+
+import "github.com/flexstack/uuid"
+
+type ProjectsData struct {
+	Projects struct {
+		Edges []struct {
+			Node struct {
+				Environments struct {
+					Edges []struct {
+						Node struct {
+							ID uuid.UUID `json:"id"`
+						} `json:"node"`
+					} `json:"edges"`
+				} `json:"environments"`
+			} `json:"node"`
+		} `json:"edges"`
+	} `json:"projects"`
+}

--- a/internal/railway/gql/queries/queries.go
+++ b/internal/railway/gql/queries/queries.go
@@ -5,6 +5,9 @@ import _ "embed"
 //go:embed project.graphql
 var ProjectQuery string
 
+//go:embed projects.graphql
+var ProjectsQuery string
+
 //go:embed environment.graphql
 var EnvironmentQuery string
 

--- a/internal/railway/subscribe/deployment_changes/helpers.go
+++ b/internal/railway/subscribe/deployment_changes/helpers.go
@@ -1,23 +1,15 @@
 package deployment_changes
 
 import (
-	"slices"
-
 	"github.com/brody192/locomotive/internal/railway/gql/queries"
-	"github.com/flexstack/uuid"
 )
 
-func findSuccessfulDeploymentsIdsForWantedServiceIds(environment *queries.EnvironmentData, wantedServiceIds []uuid.UUID) []DeploymentIdWithInfo {
+func findSuccessfulDeploymentsIdsForWantedServiceIds(environment *queries.EnvironmentData) []DeploymentIdWithInfo {
 	successfulDeploymentsIdsForWantedServiceIds := []DeploymentIdWithInfo{}
 
 	for _, deployment := range environment.Environment.Deployments.Edges {
 		// Only consider successful deployments
 		if deployment.Node.Status != "SUCCESS" {
-			continue
-		}
-
-		// Only consider deployments for the specified trains
-		if !slices.Contains(wantedServiceIds, deployment.Node.ServiceID) {
 			continue
 		}
 

--- a/internal/railway/subscribe/deployment_changes/subscribe.go
+++ b/internal/railway/subscribe/deployment_changes/subscribe.go
@@ -16,7 +16,7 @@ import (
 	"github.com/brody192/locomotive/internal/slice"
 )
 
-func SubscribeToDeploymentIdChanges(ctx context.Context, g *railway.GraphQLClient, deploymentIdSlice *slice.Sync[DeploymentIdWithInfo], changeDetected chan<- struct{}, environmentId uuid.UUID, serviceIds []uuid.UUID) error {
+func SubscribeToDeploymentIdChanges(ctx context.Context, g *railway.GraphQLClient, deploymentIdSlice *slice.Sync[DeploymentIdWithInfo], changeDetected chan<- struct{}, environmentId uuid.UUID) error {
 	environment := &queries.EnvironmentData{}
 
 	variables := map[string]any{
@@ -27,7 +27,7 @@ func SubscribeToDeploymentIdChanges(ctx context.Context, g *railway.GraphQLClien
 		return err
 	}
 
-	deploymentIdSlice.AppendMany(findSuccessfulDeploymentsIdsForWantedServiceIds(environment, serviceIds))
+	deploymentIdSlice.AppendMany(findSuccessfulDeploymentsIdsForWantedServiceIds(environment))
 
 	changeDetected <- struct{}{}
 
@@ -62,7 +62,7 @@ func SubscribeToDeploymentIdChanges(ctx context.Context, g *railway.GraphQLClien
 				return fmt.Errorf("error getting environment data for new environment hash: %w", err)
 			}
 
-			latestSuccessfulDeploymentIdsForWantedServiceIds := findSuccessfulDeploymentsIdsForWantedServiceIds(environment, serviceIds)
+			latestSuccessfulDeploymentIdsForWantedServiceIds := findSuccessfulDeploymentsIdsForWantedServiceIds(environment)
 
 			if len(latestSuccessfulDeploymentIdsForWantedServiceIds) == 0 {
 				// logger.Stdout.Debug("no new deployment id(s) for wanted service id(s)", slog.String("hash", environmentHash))

--- a/internal/railway/subscribe/http_logs/subscribe.go
+++ b/internal/railway/subscribe/http_logs/subscribe.go
@@ -82,9 +82,9 @@ func SubscribeToHttpLogs(ctx context.Context, g *railway.GraphQLClient, logTrack
 	ctx = context.WithValue(ctx, funcInitTimeKey, time.Now())
 
 	go func() {
-		logger.Stdout.Debug("starting deployment ID changes subscription", slog.String("environment_id", environmentId.String()), slog.Any("service_ids", serviceIds))
+		logger.Stdout.Debug("starting deployment ID changes subscription", slog.String("environment_id", environmentId.String()))
 
-		if err := deployment_changes.SubscribeToDeploymentIdChanges(ctx, g, deploymentIdSlice, changeDetected, environmentId, serviceIds); err != nil {
+		if err := deployment_changes.SubscribeToDeploymentIdChanges(ctx, g, deploymentIdSlice, changeDetected, environmentId); err != nil {
 			if errors.Is(err, context.Canceled) {
 				errorChan <- ctx.Err()
 				return

--- a/main.go
+++ b/main.go
@@ -27,27 +27,20 @@ func main() {
 		os.Exit(1)
 	}
 
-	allServicesExist, foundServices, missingServices, err := railway.VerifyAllServicesExistWithinEnvironment(gqlClient, config.Global.ServiceIds, config.Global.EnvironmentId)
-	if err != nil {
-		logger.Stderr.Error("error verifying if services exist within the environment", logger.ErrAttr(err))
-		os.Exit(1)
-	}
+	environmentIds := config.Global.EnvironmentIds
+	if len(environmentIds) == 0 {
+		fetchedEnvironmentIds, err := railway.FetchAllEnvironmentIDs(context.Background(), gqlClient)
+		if err != nil {
+			logger.Stderr.Error("error fetching environment ids", logger.ErrAttr(err))
+			os.Exit(1)
+		}
 
-	if !allServicesExist {
-		logger.Stderr.Error("all services must exist within the environment set by the LOCOMOTIVE_ENVIRONMENT_ID variable",
-			slog.Any("missing_service_ids", missingServices),
-			slog.Any("configured_service_ids", config.Global.ServiceIds),
-			slog.Any("found_service_ids", foundServices),
-			slog.Any("environment_id", config.Global.EnvironmentId),
-		)
-
-		os.Exit(1)
+		environmentIds = fetchedEnvironmentIds
 	}
 
 	logger.Stdout.Info("The locomotive is ready to depart...",
 		slog.String("webhook_url_host", config.Global.WebhookUrl.Host),
-		slog.Any("service_ids", config.Global.ServiceIds),
-		slog.Any("environment_id", config.Global.EnvironmentId),
+		slog.Any("environment_ids", environmentIds),
 		slog.Any("webhook_mode", config.Global.WebhookMode),
 		slog.Bool("enable_http_logs", config.Global.EnableHttpLogs),
 		slog.Bool("enable_deploy_logs", config.Global.EnableDeployLogs),
@@ -75,7 +68,17 @@ func main() {
 			return nil
 		}
 
-		return startStreamingDeployLogs(ctx, gqlClient, serviceLogTrack, config.Global.EnvironmentId, config.Global.ServiceIds)
+		deployLogGroup := errgroup.NewErrGroup()
+
+		for _, environmentId := range environmentIds {
+			environmentId := environmentId
+
+			deployLogGroup.Go(func() error {
+				return startStreamingDeployLogs(ctx, gqlClient, serviceLogTrack, environmentId, nil)
+			})
+		}
+
+		return deployLogGroup.Wait()
 	})
 
 	errGroup.Go(func() error {
@@ -84,7 +87,17 @@ func main() {
 			return nil
 		}
 
-		return startStreamingHttpLogs(ctx, gqlClient, httpLogTrack, config.Global.EnvironmentId, config.Global.ServiceIds)
+		httpLogGroup := errgroup.NewErrGroup()
+
+		for _, environmentId := range environmentIds {
+			environmentId := environmentId
+
+			httpLogGroup.Go(func() error {
+				return startStreamingHttpLogs(ctx, gqlClient, httpLogTrack, environmentId, nil)
+			})
+		}
+
+		return httpLogGroup.Wait()
 	})
 
 	logger.Stdout.Info("The locomotive is waiting for cargo...")


### PR DESCRIPTION
## Resumo
- Adiciona suporte a LOCOMOTIVE_ENVIRONMENT_IDS como lista separada por vírgula.
- Quando a variável está vazia, consulta a Railway para descobrir todos os environment IDs acessíveis.
- Remove o filtro por service ids na descoberta de deployments e processa cada environment em paralelo.

## Como testar
- go test ./...
- Executar a aplicação com LOCOMOTIVE_ENVIRONMENT_IDS preenchida e vazia para validar os dois caminhos.
