### PR TITLE
feat: add SigNoz Cloud webhook mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,13 +235,14 @@ Configuration is done through environment variables. See explanation and example
 
 #### SigNoz
 
+> [!NOTE]
+> The `signoz` mode targets **SigNoz Cloud** only. For self-hosted SigNoz, use the [`otel_http`](#opentelemetry-http) mode with your OTel Collector URL (e.g. `http://<SIGNOZ_HOSTNAME>:4318/v1/logs`).
+
 - `LOCOMOTIVE_WEBHOOK_MODE` - `signoz`
 
 - `LOCOMOTIVE_WEBHOOK_URL` - `https://ingest.<REGION>.signoz.cloud:443/v1/logs`
 
     Replace `<REGION>` with your SigNoz Cloud region (e.g. `us`, `in`, `eu`).
-
-    For self-hosted SigNoz, use the URL of your OTel Collector (e.g. `https://<SIGNOZ_HOSTNAME>:4318/v1/logs`).
 
 - `LOCOMOTIVE_ADDITIONAL_HEADERS` - `signoz-ingestion-key=<SIGNOZ_INGESTION_KEY>`
 

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Configuration is done through environment variables. See explanation and example
 
 - `LOCOMOTIVE_ADDITIONAL_HEADERS` - `signoz-ingestion-key=<SIGNOZ_INGESTION_KEY>`
 
-    The ingestion key can be found in your SigNoz Cloud dashboard under 'Settings' > 'Ingestion Settings'.
+    The ingestion URL and key can be found in your SigNoz Cloud dashboard under 'Settings' > 'Ingestion Settings'. See the [SigNoz Cloud Ingestion docs](https://signoz.io/docs/ingestion/signoz-cloud/overview/) for more information.
 
     </br>
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ With tailored support for:
 - Loki
 - Sentry
 - Papertrail
+- SigNoz
 - OpenTelemetry HTTP
 
 And more with the standard JSON and JSON Lines modes.
@@ -79,6 +80,7 @@ Configuration is done through environment variables. See explanation and example
     - Example for Datadog: `https://http-intake.logs.datadoghq.com/api/v2/logs`
     - Example for Axiom: `https://api.axiom.co/v1/datasets/<DATASET_NAME>/ingest`
     - Example for BetterStack: `https://in.logs.betterstack.com`
+    - Example for SigNoz: `https://ingest.<REGION>.signoz.cloud:443/v1/logs`
     - Example for OpenTelemetry HTTP: `https://<OTEL_HTTP_ENDPOINT>/v1/logs`
 
     See [Provider specific setup](#provider-specific-setup) for more information.
@@ -114,6 +116,7 @@ Configuration is done through environment variables. See explanation and example
     - `betterstack`
     - `loki`
     - `sentry`
+    - `signoz`
     - `otel_http`
 
     </br>
@@ -227,6 +230,22 @@ Configuration is done through environment variables. See explanation and example
 - `LOCOMOTIVE_ADDITIONAL_HEADERS` - `X-Sentry-Auth=Sentry sentry_key=<SENTRY_KEY>`
 
     The key can again be found in the 'Client Keys (DSN)' section of the Sentry project settings; it will be the user part of the given DSN.
+
+    </br>
+
+#### SigNoz
+
+- `LOCOMOTIVE_WEBHOOK_MODE` - `signoz`
+
+- `LOCOMOTIVE_WEBHOOK_URL` - `https://ingest.<REGION>.signoz.cloud:443/v1/logs`
+
+    Replace `<REGION>` with your SigNoz Cloud region (e.g. `us`, `in`, `eu`).
+
+    For self-hosted SigNoz, use the URL of your OTel Collector (e.g. `https://<SIGNOZ_HOSTNAME>:4318/v1/logs`).
+
+- `LOCOMOTIVE_ADDITIONAL_HEADERS` - `signoz-ingestion-key=<SIGNOZ_INGESTION_KEY>`
+
+    The ingestion key can be found in your SigNoz Cloud dashboard under 'Settings' > 'Ingestion Settings'.
 
     </br>
 

--- a/internal/config/data.go
+++ b/internal/config/data.go
@@ -95,7 +95,7 @@ var WebhookModeToConfig = map[WebhookMode]WebhookConfig{
 		HTTPLogReconstructorFunc:        reconstruct_otel.HttpLogsOtel,
 	},
 	WebhookModeSignoz: {
-		ExpectedHostContains:            []string{"signoz"},
+		ExpectedHostContains:            []string{"signoz.cloud"},
 		ExpectedHeaders:                 []string{"signoz-ingestion-key"},
 		Headers:                         map[string]string{},
 		EnvironmentLogReconstructorFunc: reconstruct_otel.EnvironmentLogsOtel,

--- a/internal/config/data.go
+++ b/internal/config/data.go
@@ -25,6 +25,7 @@ const (
 	WebhookModeLoki        WebhookMode = "loki"
 	WebhookModeSentry      WebhookMode = "sentry"
 	WebhookModeOtelHTTP    WebhookMode = "otel_http"
+	WebhookModeSignoz      WebhookMode = "signoz"
 
 	DefaultWebhookMode = WebhookModeJson
 )
@@ -89,6 +90,13 @@ var WebhookModeToConfig = map[WebhookMode]WebhookConfig{
 		HTTPLogReconstructorFunc:        reconstruct_sentry.HttpLogsEnvelope,
 	},
 	WebhookModeOtelHTTP: {
+		Headers:                         map[string]string{},
+		EnvironmentLogReconstructorFunc: reconstruct_otel.EnvironmentLogsOtel,
+		HTTPLogReconstructorFunc:        reconstruct_otel.HttpLogsOtel,
+	},
+	WebhookModeSignoz: {
+		ExpectedHostContains:            []string{"signoz"},
+		ExpectedHeaders:                 []string{"signoz-ingestion-key"},
 		Headers:                         map[string]string{},
 		EnvironmentLogReconstructorFunc: reconstruct_otel.EnvironmentLogsOtel,
 		HTTPLogReconstructorFunc:        reconstruct_otel.HttpLogsOtel,


### PR DESCRIPTION
## Summary

Adds a dedicated `signoz` webhook mode for forwarding Railway logs to [SigNoz Cloud](https://signoz.io).

## Changes

- **`internal/config/data.go`**: New `signoz` webhook mode with `signoz.cloud` host validation and `signoz-ingestion-key` header requirement
- **`README.md`**: Documentation for the SigNoz provider setup

## Configuration

```env
LOCOMOTIVE_WEBHOOK_MODE=signoz
LOCOMOTIVE_WEBHOOK_URL=https://ingest.<REGION>.signoz.cloud:443/v1/logs
LOCOMOTIVE_ADDITIONAL_HEADERS=signoz-ingestion-key=<SIGNOZ_INGESTION_KEY>
```

Replace `<REGION>` with your SigNoz Cloud region (e.g. `us`, `in`, `eu`). The ingestion URL and key can be found in your SigNoz Cloud dashboard under Settings > Ingestion Settings.

## Notes

- Reuses the existing OTLP reconstructor: logs are forwarded as standard OTLP JSON, which SigNoz Cloud accepts natively on the `/v1/logs` endpoint