### PR TITLE
Add VictoriaLogs webhook mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ With tailored support for:
 - Sentry
 - Papertrail
 - SigNoz
+- VictoriaLogs
 - OpenTelemetry HTTP
 
 And more with the standard JSON and JSON Lines modes.
@@ -81,6 +82,7 @@ Configuration is done through environment variables. See explanation and example
     - Example for Axiom: `https://api.axiom.co/v1/datasets/{DATASET_NAME}/ingest`
     - Example for BetterStack: `https://in.logs.betterstack.com`
     - Example for SigNoz: `https://ingest.{REGION}.signoz.cloud:443/v1/logs`
+    - Example for VictoriaLogs: `https://{VICTORIALOGS_HOSTNAME}/insert/jsonline`
     - Example for OpenTelemetry HTTP: `https://{OTEL_HTTP_ENDPOINT}/v1/logs`
 
     See [Provider specific setup](#provider-specific-setup) for more information.
@@ -117,6 +119,7 @@ Configuration is done through environment variables. See explanation and example
     - `loki`
     - `sentry`
     - `signoz`
+    - `victorialogs`
     - `otel_http`
 
     </br>
@@ -247,6 +250,24 @@ Configuration is done through environment variables. See explanation and example
 - `LOCOMOTIVE_ADDITIONAL_HEADERS` - `signoz-ingestion-key={SIGNOZ_INGESTION_KEY}`
 
     The ingestion URL and key can be found in your SigNoz Cloud dashboard under 'Settings' > 'Ingestion Settings'. See the [SigNoz Cloud Ingestion docs](https://signoz.io/docs/ingestion/signoz-cloud/overview/) for more information.
+
+    </br>
+
+#### VictoriaLogs
+
+- `LOCOMOTIVE_WEBHOOK_MODE` - `victorialogs`
+
+- `LOCOMOTIVE_WEBHOOK_URL` - `https://{VICTORIALOGS_HOSTNAME}/insert/jsonline`
+
+    The hostname depends on where you are running VictoriaLogs. The endpoint accepts JSON-line ingestion at `/insert/jsonline`. See the [VictoriaLogs JSON ingestion docs](https://docs.victoriametrics.com/victorialogs/data-ingestion/#json-stream-api) for details.
+
+    Use the `_stream_fields` query parameter to declare which fields identify a log stream (e.g. service / environment), for example:
+
+    `https://{VICTORIALOGS_HOSTNAME}/insert/jsonline?_stream_fields=_metadata.service_name,_metadata.environment_name`
+
+    Or, with username and password authentication:
+
+    `https://{USERNAME}:{PASSWORD}@{VICTORIALOGS_HOSTNAME}/insert/jsonline`
 
     </br>
 

--- a/internal/config/data.go
+++ b/internal/config/data.go
@@ -11,21 +11,23 @@ import (
 	"github.com/brody192/locomotive/internal/logline/reconstructor/reconstruct_otel"
 	"github.com/brody192/locomotive/internal/logline/reconstructor/reconstruct_papertrail"
 	"github.com/brody192/locomotive/internal/logline/reconstructor/reconstruct_sentry"
+	"github.com/brody192/locomotive/internal/logline/reconstructor/reconstruct_victorialogs"
 )
 
 var schemeRegex = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+.-]*://`)
 
 const (
-	WebhookModeJson        WebhookMode = "json"
-	WebhookModeJsonl       WebhookMode = "jsonl"
-	WebhookModePapertrail  WebhookMode = "papertrail"
-	WebhookModeDatadog     WebhookMode = "datadog"
-	WebhookModeAxiom       WebhookMode = "axiom"
-	WebhookModeBetterstack WebhookMode = "betterstack"
-	WebhookModeLoki        WebhookMode = "loki"
-	WebhookModeSentry      WebhookMode = "sentry"
-	WebhookModeOtelHTTP    WebhookMode = "otel_http"
-	WebhookModeSignoz      WebhookMode = "signoz"
+	WebhookModeJson         WebhookMode = "json"
+	WebhookModeJsonl        WebhookMode = "jsonl"
+	WebhookModePapertrail   WebhookMode = "papertrail"
+	WebhookModeDatadog      WebhookMode = "datadog"
+	WebhookModeAxiom        WebhookMode = "axiom"
+	WebhookModeBetterstack  WebhookMode = "betterstack"
+	WebhookModeLoki         WebhookMode = "loki"
+	WebhookModeSentry       WebhookMode = "sentry"
+	WebhookModeOtelHTTP     WebhookMode = "otel_http"
+	WebhookModeSignoz       WebhookMode = "signoz"
+	WebhookModeVictoriaLogs WebhookMode = "victorialogs"
 
 	DefaultWebhookMode = WebhookModeJson
 )
@@ -100,5 +102,13 @@ var WebhookModeToConfig = map[WebhookMode]WebhookConfig{
 		Headers:                         map[string]string{},
 		EnvironmentLogReconstructorFunc: reconstruct_otel.EnvironmentLogsOtel,
 		HTTPLogReconstructorFunc:        reconstruct_otel.HttpLogsOtel,
+	},
+	WebhookModeVictoriaLogs: {
+		ExpectedHostContains: []string{"victorialogs", "victoriametrics"},
+		Headers: map[string]string{
+			"Content-Type": "application/stream+json",
+		},
+		EnvironmentLogReconstructorFunc: reconstruct_victorialogs.EnvironmentLogsJsonLines,
+		HTTPLogReconstructorFunc:        reconstruct_victorialogs.HttpLogsJsonLines,
 	},
 }

--- a/internal/logline/reconstructor/reconstruct_json/environment.go
+++ b/internal/logline/reconstructor/reconstruct_json/environment.go
@@ -62,7 +62,12 @@ func environmentLogJson(log environment_logs.EnvironmentLogWithMetadata, config 
 		object, _ = sjson.SetBytes(object, fmt.Sprintf("_metadata.%s", key), value)
 	}
 
-	object, _ = sjson.SetBytes(object, "message", util.StripAnsi(log.Log.Message))
+	messageAttribute := config.MessageAttribute
+	if messageAttribute == "" {
+		messageAttribute = "message"
+	}
+
+	object, _ = sjson.SetBytes(object, messageAttribute, util.StripAnsi(log.Log.Message))
 
 	object, _ = sjson.SetBytes(object, "severity", log.Log.Severity)
 

--- a/internal/logline/reconstructor/reconstruct_json/http.go
+++ b/internal/logline/reconstructor/reconstruct_json/http.go
@@ -60,7 +60,12 @@ func httpLogLineJson(log http_logs.DeploymentHttpLogWithMetadata, config Config)
 		object, _ = sjson.SetBytes(object, fmt.Sprintf("_metadata.%s", key), value)
 	}
 
-	object, _ = sjson.SetBytes(object, "message", log.Path)
+	messageAttribute := config.MessageAttribute
+	if messageAttribute == "" {
+		messageAttribute = "message"
+	}
+
+	object, _ = sjson.SetBytes(object, messageAttribute, log.Path)
 
 	for _, attribute := range config.ReserverdAttributes {
 		attr := gjson.GetBytes(object, attribute)

--- a/internal/logline/reconstructor/reconstruct_json/types.go
+++ b/internal/logline/reconstructor/reconstruct_json/types.go
@@ -2,6 +2,7 @@ package reconstruct_json
 
 type Config struct {
 	TimestampAttribute   string
+	MessageAttribute     string
 	ReserverdAttributes  []string
 	AdditionalFieldsFunc func(metadata map[string]string) map[string]any
 }

--- a/internal/logline/reconstructor/reconstruct_victorialogs/data.go
+++ b/internal/logline/reconstructor/reconstruct_victorialogs/data.go
@@ -1,0 +1,13 @@
+package reconstruct_victorialogs
+
+// https://docs.victoriametrics.com/victorialogs/data-ingestion/#http-parameters
+//
+// VictoriaLogs' JSON stream ingestion API expects each line to be a JSON
+// object. By default it looks for the log message under "_msg" and the
+// timestamp under "_time" (these can be remapped via _msg_field / _time_field
+// query parameters, but we use the defaults to keep configuration minimal).
+
+const (
+	timestampAttribute = "_time"
+	messageAttribute   = "_msg"
+)

--- a/internal/logline/reconstructor/reconstruct_victorialogs/environment.go
+++ b/internal/logline/reconstructor/reconstruct_victorialogs/environment.go
@@ -1,0 +1,13 @@
+package reconstruct_victorialogs
+
+import (
+	"github.com/brody192/locomotive/internal/logline/reconstructor/reconstruct_json"
+	"github.com/brody192/locomotive/internal/railway/subscribe/environment_logs"
+)
+
+func EnvironmentLogsJsonLines(logs []environment_logs.EnvironmentLogWithMetadata) ([]byte, error) {
+	return reconstruct_json.EnvironmentLogsJsonLinesWithConfig(logs, reconstruct_json.Config{
+		TimestampAttribute: timestampAttribute,
+		MessageAttribute:   messageAttribute,
+	})
+}

--- a/internal/logline/reconstructor/reconstruct_victorialogs/http.go
+++ b/internal/logline/reconstructor/reconstruct_victorialogs/http.go
@@ -1,0 +1,13 @@
+package reconstruct_victorialogs
+
+import (
+	"github.com/brody192/locomotive/internal/logline/reconstructor/reconstruct_json"
+	"github.com/brody192/locomotive/internal/railway/subscribe/http_logs"
+)
+
+func HttpLogsJsonLines(logs []http_logs.DeploymentHttpLogWithMetadata) ([]byte, error) {
+	return reconstruct_json.HttpLogsJsonLinesWithConfig(logs, reconstruct_json.Config{
+		TimestampAttribute: timestampAttribute,
+		MessageAttribute:   messageAttribute,
+	})
+}


### PR DESCRIPTION
## Summary

Adds a new `victorialogs` webhook mode for shipping logs to VictoriaLogs.

- Sends logs to VictoriaLogs' `/insert/jsonline` ingestion endpoint
- Built on the existing JSON reconstructor with a couple of added fields
- README updated with setup instructions, `_stream_fields` usage, and basic-auth URL example

[VictoriaLogs documentation](https://docs.victoriametrics.com/victorialogs/data-ingestion/)

## Configuration

```env
LOCOMOTIVE_WEBHOOK_MODE=victorialogs
LOCOMOTIVE_WEBHOOK_URL=https://{VICTORIALOGS_HOSTNAME}/insert/jsonline
```

  Optionally declare stream fields:
```env
LOCOMOTIVE_WEBHOOK_URL=https://{VICTORIALOGS_HOSTNAME}/insert/jsonline?_stream_fields=_metadata.service_name,_metadata.environment_name
```