### PR TITLE
feat(sentry): forward Railway environment as native sentry.environment

### DIFF
--- a/internal/logline/reconstructor/reconstruct_sentry/data.go
+++ b/internal/logline/reconstructor/reconstruct_sentry/data.go
@@ -4,5 +4,5 @@ const (
 	LineOne   string = `{"event_id":"","sent_at":"","sdk":{"name":"locomotive","version":"2.0.0"}}`
 	LineTwo   string = `{"type":"log","item_count":1,"content_type":"application/vnd.sentry.items.log+json"}`
 	LineThree string = `{"event_id":"","level":"info","platform":"go","sdk":{"name":"locomotive","version":"2.0.0","integrations":[],"packages":[]},"server_name":"locomotive","user":{},"modules":{},"items":[],"timestamp":""}`
-	Item      string = `{"timestamp":"","trace_id":"","level":"","severity_number":9,"body":"","attributes":{"sentry.sdk.name":{"value":"locomotive","type":"string"},"sentry.sdk.version":{"value":"2.0.0","type":"string"},"sentry.server.address":{"value":"locomotive","type":"string"}}}`
+	Item      string = `{"timestamp":"","trace_id":"","level":"","severity_number":9,"body":"","attributes":{"sentry.sdk.name":{"value":"locomotive","type":"string"},"sentry.sdk.version":{"value":"2.0.0","type":"string"},"sentry.server.address":{"value":"locomotive","type":"string"},"sentry.environment":{"value":"","type":"string"},"sentry.origin":{"value":"auto.log.locomotive","type":"string"}}}`
 )

--- a/internal/logline/reconstructor/reconstruct_sentry/environment.go
+++ b/internal/logline/reconstructor/reconstruct_sentry/environment.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/brody192/locomotive/internal/logline/reconstructor"
 	"github.com/brody192/locomotive/internal/logline/reconstructor/reconstruct_sentry/sentry_attribute"
+	"github.com/brody192/locomotive/internal/railway/subscribe"
 	"github.com/brody192/locomotive/internal/railway/subscribe/environment_logs"
 	"github.com/brody192/locomotive/internal/util"
 )
@@ -54,6 +55,10 @@ func EnvironmentLogsEnvelope(logs []environment_logs.EnvironmentLogWithMetadata)
 
 		for key, value := range logs[i].Metadata {
 			item, _ = sjson.SetRawBytes(item, ("attributes._metadata__" + key), sentry_attribute.StringValue(value).RawJSON())
+		}
+
+		if env := logs[i].Metadata[subscribe.MetadataKeyEnvironmentName]; env != "" {
+			item, _ = sjson.SetBytes(item, `attributes.sentry\.environment.value`, env)
 		}
 
 		items = append(items, item)

--- a/internal/logline/reconstructor/reconstruct_sentry/http.go
+++ b/internal/logline/reconstructor/reconstruct_sentry/http.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/brody192/locomotive/internal/logline/reconstructor"
 	"github.com/brody192/locomotive/internal/logline/reconstructor/reconstruct_sentry/sentry_attribute"
+	"github.com/brody192/locomotive/internal/railway/subscribe"
 	"github.com/brody192/locomotive/internal/railway/subscribe/http_logs"
 	"github.com/tidwall/sjson"
 )
@@ -42,6 +43,10 @@ func HttpLogsEnvelope(logs []http_logs.DeploymentHttpLogWithMetadata) ([]byte, e
 
 		for key, value := range logs[i].Metadata {
 			item, _ = sjson.SetRawBytes(item, ("attributes._metadata__" + key), sentry_attribute.StringValue(value).RawJSON())
+		}
+
+		if env := logs[i].Metadata[subscribe.MetadataKeyEnvironmentName]; env != "" {
+			item, _ = sjson.SetBytes(item, `attributes.sentry\.environment.value`, env)
 		}
 
 		items = append(items, item)


### PR DESCRIPTION
## What

Forward the Railway **environment** to Sentry's *native* environment dimension so logs become filterable by environment in the Sentry UI — previously the environment name only showed up as a generic `_metadata__environment_name` attribute, which Sentry treats as an arbitrary custom field.

## How

Reverse-engineered the sentry-go logs SDK to find the reserved attribute keys:

- **`sentry.environment`** — declared (empty) in the `Item` template next to the existing `sentry.*` defaults, then filled per-log from the `environment_name` metadata in both the environment-log and HTTP-log reconstructors. The `\.` in the sjson path escapes the dot so the flat reserved key `sentry.environment` is addressed rather than a nested `sentry` → `environment` path.
- **`sentry.origin`** — added as the constant `auto.log.locomotive` (baked straight into the template, no per-item work), labeling the logs' source in Sentry per the `auto.log.<integration>` convention used by the official SDK integrations.

The change is additive — the existing `_metadata__environment_name` attribute is preserved.

## Notes / decisions

- **`server.address`** — verified against sentry-go source that the Go SDK uses the prefixed `sentry.server.address`, so the existing template key was already correct; left unchanged.
- **`sentry.release`** — intentionally *not* added. In the SDK, `release` is a code-version identifier (git commit SHA / `package@version`); the only value locomotive has handy is the deployment UUID, which would be semantically wrong and wouldn't power Sentry's release/regression features. Populating it correctly would require fetching Railway's commit hash via the deployment GraphQL query — out of scope here.

## Test plan

- `go build ./...` ✅
- `go vet ./internal/logline/reconstructor/reconstruct_sentry/` ✅
- `Item` template validated as well-formed JSON with the new attributes present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)